### PR TITLE
feat(kubernetes): update to 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MODULES ?= $(shell find * -type d | grep -v '/\.')
+MODULES ?= $(shell find * -type d | grep -v '/\.' | grep -v 'modules')
 ROOT ?= $(shell pwd)
 
 default: lint

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -11,22 +11,7 @@ provider "aws" {
   region = "us-west-2"
 }
 
-locals {
-  allowed_cidr_blocks       = ["136.24.147.41/32"]
-  cluster_endpoint          = "k8s.pokedextracker.com"
-  cluster_endpoint_internal = "k8s.internal.pokedextracker.com"
-  kube2iam_iam_path         = "/kubernetes/${local.name}/"
-  kubernetes_version        = "1.14.1"
-  master_count              = 1
-  name                      = "pokedextracker"
-  pod_subnet                = "192.168.0.0/16"
-  service_subnet            = "192.168.20.0/16"
-  worker_count              = 1
-}
-
 data "aws_caller_identity" "current" {}
-
-data "aws_region" "current" {}
 
 data "terraform_remote_state" "dns" {
   backend = "s3"
@@ -52,44 +37,36 @@ data "aws_subnet" "public" {
   id = "${data.terraform_remote_state.network.public_subnets.0}"
 }
 
+# To get the latest one, run the following:
+# aws ec2 describe-images --owners 099720109477 --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*' | jq -r '.Images | sort_by(.CreationDate) | reverse[] | .Name' | head -n 1
 data "aws_ami" "ubuntu" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190320"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200408"]
   }
 
   owners = ["099720109477"] # Canonical
 }
 
+# command to create new key pair:
+# ssh-keygen -t rsa -f ~/.ssh/pokedextracker-kubernetes -P '' -C pokedextracker-kubernetes
 resource "aws_key_pair" "kubernetes" {
-  key_name   = "${local.name}-kubernetes"
+  key_name   = "pokedextracker-kubernetes"
   public_key = "${file("pokedextracker-kubernetes.pub")}"
 }
 
-resource "aws_kms_key" "kubernetes" {
-  description             = "${local.name}-kubernetes"
-  deletion_window_in_days = 30
-  enable_key_rotation     = true
-  is_enabled              = true
+module "cluster_blue" {
+  source = "../modules/kubernetes_cluster"
 
-  tags {
-    Name    = "${local.name}-kubernetes"
-    Project = "PokedexTracker"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_kms_alias" "kubernetes" {
-  name          = "alias/${local.name}-kubernetes"
-  target_key_id = "${aws_kms_key.kubernetes.id}"
+  allowed_cidr_blocks = ["136.24.147.41/32"]
+  ami_id              = "${data.aws_ami.ubuntu.id}"
+  dns_zone_id         = "${data.terraform_remote_state.dns.zone_id}"
+  key_name            = "${aws_key_pair.kubernetes.key_name}"
+  kubernetes_version  = "1.18.2"
+  master_count        = 1
+  name                = "pokedextracker"
+  subnet_id           = "${data.terraform_remote_state.network.public_subnets.0}"
+  worker_count        = 1
 }

--- a/kubernetes/outputs.tf
+++ b/kubernetes/outputs.tf
@@ -3,13 +3,13 @@ output "account_id" {
 }
 
 output "cert_manager_iam_role_name" {
-  value = "${aws_iam_role.cert_manager.name}"
+  value = "${module.cluster_blue.cert_manager_iam_role_name}"
 }
 
 output "cluster_endpoint" {
-  value = "${local.cluster_endpoint}"
+  value = "${module.cluster_blue.cluster_endpoint}"
 }
 
 output "kube2iam_iam_path" {
-  value = "${local.kube2iam_iam_path}"
+  value = "${module.cluster_blue.kube2iam_iam_path}"
 }

--- a/modules/kubernetes_cluster/cert-manager.tf
+++ b/modules/kubernetes_cluster/cert-manager.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "cert_manager" {
 
   statement {
     actions   = ["route53:ChangeResourceRecordSets"]
-    resources = ["arn:aws:route53:::hostedzone/${data.terraform_remote_state.dns.zone_id}"]
+    resources = ["arn:aws:route53:::hostedzone/${var.dns_zone_id}"]
   }
 
   statement {
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "cert_manager" {
 }
 
 resource "aws_iam_role" "cert_manager" {
-  name               = "kubernetes-${local.name}-cert-manager"
+  name               = "kubernetes-${var.name}-${random_id.hash.hex}-cert-manager"
   path               = "${local.kube2iam_iam_path}"
   assume_role_policy = "${data.aws_iam_policy_document.cert_manager_assume_role.json}"
 }

--- a/modules/kubernetes_cluster/main.tf
+++ b/modules/kubernetes_cluster/main.tf
@@ -1,0 +1,41 @@
+data "aws_region" "current" {}
+
+data "aws_subnet" "main" {
+  id = "${var.subnet_id}"
+}
+
+data "aws_vpc" "main" {
+  id = "${data.aws_subnet.main.vpc_id}"
+}
+
+resource "random_id" "hash" {
+  byte_length = 3
+}
+
+locals {
+  cluster_endpoint          = "${random_id.hash.hex}.k8s.pokedextracker.com"
+  cluster_endpoint_internal = "${random_id.hash.hex}.k8s.internal.pokedextracker.com"
+  kube2iam_iam_path         = "/kubernetes/${var.name}/"
+}
+
+resource "aws_kms_key" "kubernetes" {
+  description             = "${var.name}-${random_id.hash.hex}-kubernetes"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  is_enabled              = true
+
+  tags {
+    Name    = "${var.name}-${random_id.hash.hex}-kubernetes"
+    Project = "PokedexTracker"
+    Module  = "kubernetes_cluster"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_kms_alias" "kubernetes" {
+  name          = "alias/${var.name}-${random_id.hash.hex}-kubernetes"
+  target_key_id = "${aws_kms_key.kubernetes.id}"
+}

--- a/modules/kubernetes_cluster/outputs.tf
+++ b/modules/kubernetes_cluster/outputs.tf
@@ -1,0 +1,11 @@
+output "cert_manager_iam_role_name" {
+  value = "${aws_iam_role.cert_manager.name}"
+}
+
+output "cluster_endpoint" {
+  value = "${local.cluster_endpoint}"
+}
+
+output "kube2iam_iam_path" {
+  value = "${local.kube2iam_iam_path}"
+}

--- a/modules/kubernetes_cluster/variables.tf
+++ b/modules/kubernetes_cluster/variables.tf
@@ -2,13 +2,17 @@ variable "allowed_cidr_blocks" {
   type = "list"
 }
 
-variable "name" {}
+variable "ami_id" {}
+
+variable "dns_zone_id" {}
+
+variable "key_name" {}
 
 variable "kubernetes_version" {}
 
 variable "master_count" {}
 
-variable "worker_count" {}
+variable "name" {}
 
 variable "pod_subnet" {
   default = "192.168.0.0/16"
@@ -22,8 +26,4 @@ variable "service_subnet" {
 # to cycle the node.
 variable "subnet_id" {}
 
-variable "key_name" {}
-
-variable "ami_id" {}
-
-variable "dns_zone_id" {}
+variable "worker_count" {}

--- a/modules/kubernetes_cluster/variables.tf
+++ b/modules/kubernetes_cluster/variables.tf
@@ -1,0 +1,29 @@
+variable "allowed_cidr_blocks" {
+  type = "list"
+}
+
+variable "name" {}
+
+variable "kubernetes_version" {}
+
+variable "master_count" {}
+
+variable "worker_count" {}
+
+variable "pod_subnet" {
+  default = "192.168.0.0/16"
+}
+
+variable "service_subnet" {
+  default = "10.96.0.0/16"
+}
+
+# We're only using 1 subnet so that our PVCs will easily be reattched if we need
+# to cycle the node.
+variable "subnet_id" {}
+
+variable "key_name" {}
+
+variable "ami_id" {}
+
+variable "dns_zone_id" {}


### PR DESCRIPTION
### what

- make `kubernetes_cluster` module to be able to create more than one cluster at a time for blue/green deploys
- ignore modules from linting
- update dns records to be accurate cause they were very out of date
- update to kubernetes v1.18.2
- update to the latest ubuntu 18.04 ami
- update docker and flannel
- constraint the cluster to one az